### PR TITLE
Add Findlay Park theme with custom palette

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -40,24 +40,28 @@
 					localStorage.theme = 'system';
 				}
 
-				if (localStorage.theme === 'system') {
-					document.documentElement.classList.add(prefersDarkTheme ? 'dark' : 'light');
-					metaThemeColorTag.setAttribute('content', prefersDarkTheme ? '#171717' : '#ffffff');
-				} else if (localStorage.theme === 'oled-dark') {
+                                if (localStorage.theme === 'system') {
+                                        document.documentElement.classList.add(prefersDarkTheme ? 'dark' : 'light');
+                                        metaThemeColorTag.setAttribute('content', prefersDarkTheme ? '#171717' : '#ffffff');
+                                } else if (localStorage.theme === 'oled-dark') {
 					document.documentElement.style.setProperty('--color-gray-800', '#101010');
 					document.documentElement.style.setProperty('--color-gray-850', '#050505');
 					document.documentElement.style.setProperty('--color-gray-900', '#000000');
 					document.documentElement.style.setProperty('--color-gray-950', '#000000');
 					document.documentElement.classList.add('dark');
 					metaThemeColorTag.setAttribute('content', '#000000');
-				} else if (localStorage.theme === 'light') {
-					document.documentElement.classList.add('light');
-					metaThemeColorTag.setAttribute('content', '#ffffff');
-				} else if (localStorage.theme === 'her') {
-					document.documentElement.classList.add('dark');
-					document.documentElement.classList.add('her');
-					metaThemeColorTag.setAttribute('content', '#983724');
-				} else {
+                                } else if (localStorage.theme === 'light') {
+                                        document.documentElement.classList.add('light');
+                                        metaThemeColorTag.setAttribute('content', '#ffffff');
+                                } else if (localStorage.theme === 'findlay-park') {
+                                        document.documentElement.classList.add('light');
+                                        document.documentElement.classList.add('findlay-park');
+                                        metaThemeColorTag.setAttribute('content', '#E2DAD3');
+                                } else if (localStorage.theme === 'her') {
+                                        document.documentElement.classList.add('dark');
+                                        document.documentElement.classList.add('her');
+                                        metaThemeColorTag.setAttribute('content', '#983724');
+                                } else {
 					document.documentElement.classList.add('dark');
 					metaThemeColorTag.setAttribute('content', '#171717');
 				}
@@ -172,13 +176,17 @@
 		background: #fff;
 	}
 
-	html.dark #splash-screen {
-		background: #000;
-	}
+        html.dark #splash-screen {
+                background: #000;
+        }
 
-	html.her #splash-screen {
-		background: #983724;
-	}
+        html.her #splash-screen {
+                background: #983724;
+        }
+
+        html.findlay-park #splash-screen {
+                background: #E2DAD3;
+        }
 
 	#logo-her {
 		display: none;

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -14,7 +14,7 @@
 	export let getModels: Function;
 
 	// General
-	let themes = ['dark', 'light', 'oled-dark'];
+        let themes = ['dark', 'light', 'oled-dark', 'findlay-park light'];
 	let selectedTheme = 'system';
 
 	let languages: Awaited<ReturnType<typeof getLanguages>> = [];
@@ -117,7 +117,12 @@
 	});
 
 	const applyTheme = (_theme: string) => {
-		let themeToApply = _theme === 'oled-dark' ? 'dark' : _theme;
+                let themeToApply =
+                        _theme === 'oled-dark'
+                                ? 'dark'
+                                : _theme === 'findlay-park'
+                                        ? 'findlay-park light'
+                                        : _theme;
 
 		if (_theme === 'system') {
 			themeToApply = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -152,16 +157,18 @@
 				metaThemeColor.setAttribute('content', systemTheme === 'light' ? '#ffffff' : '#171717');
 			} else {
 				console.log('Setting meta theme color: ' + _theme);
-				metaThemeColor.setAttribute(
-					'content',
-					_theme === 'dark'
-						? '#171717'
-						: _theme === 'oled-dark'
-							? '#000000'
-							: _theme === 'her'
-								? '#983724'
-								: '#ffffff'
-				);
+                                metaThemeColor.setAttribute(
+                                        'content',
+                                        _theme === 'dark'
+                                                ? '#171717'
+                                                : _theme === 'oled-dark'
+                                                        ? '#000000'
+                                                        : _theme === 'her'
+                                                                ? '#983724'
+                                                                : _theme === 'findlay-park'
+                                                                        ? '#E2DAD3'
+                                                                        : '#ffffff'
+                                );
 			}
 		}
 
@@ -205,12 +212,13 @@
 					>
 						<option value="system">⚙️ {$i18n.t('System')}</option>
 						<option value="dark">🌑 {$i18n.t('Dark')}</option>
-						<option value="oled-dark">🌃 {$i18n.t('OLED Dark')}</option>
-						<option value="light">☀️ {$i18n.t('Light')}</option>
-						<option value="her">🌷 Her</option>
-						<!-- <option value="rose-pine dark">🪻 {$i18n.t('Rosé Pine')}</option>
-						<option value="rose-pine-dawn light">🌷 {$i18n.t('Rosé Pine Dawn')}</option> -->
-					</select>
+                                                <option value="oled-dark">🌃 {$i18n.t('OLED Dark')}</option>
+                                                <option value="light">☀️ {$i18n.t('Light')}</option>
+                                                <option value="findlay-park">🌲 Findlay Park</option>
+                                                <option value="her">🌷 Her</option>
+                                                <!-- <option value="rose-pine dark">🪻 {$i18n.t('Rosé Pine')}</option>
+                                                <option value="rose-pine-dawn light">🌷 {$i18n.t('Rosé Pine Dawn')}</option> -->
+                                        </select>
 				</div>
 			</div>
 

--- a/static/static/custom.css
+++ b/static/static/custom.css
@@ -1,0 +1,19 @@
+
+/* Findlay Park theme */
+.findlay-park .app > * {
+        background-color: #E2DAD3 !important;
+}
+
+.findlay-park #sidebar,
+.findlay-park #sidebar > div {
+        background-color: #E9E3DE;
+}
+
+.findlay-park .bg-white {
+        background-color: #E2DAD3;
+}
+
+.findlay-park .bg-gray-50 {
+        background-color: #E9E3DE;
+}
+


### PR DESCRIPTION
## Summary
- add Findlay Park theme option with light background and sidebar colors
- support new theme at startup and in settings
- style background and sidebar for the theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm run lint:frontend` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68906ad929c8832cb7502d25a7752bf2