### PR TITLE
Remove pull request trigger from Docker Image CI workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Eliminate the pull request trigger from the Docker Image CI workflow to streamline the process.