### PR TITLE
Dev into Main

### DIFF
--- a/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
+++ b/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
@@ -22,12 +22,16 @@
 
 	const submitHandler = async () => {
 		// Normalize Windows CRLF (\r\n) to LF (\n) for all string values
+		// Build a new object to avoid mutating the reactive variableValues proxy
+		const result = {};
 		for (const key of Object.keys(variableValues)) {
 			if (typeof variableValues[key] === 'string') {
-				variableValues[key] = variableValues[key].replace(/\r\n/g, '\n');
+				result[key] = variableValues[key].replace(/\r\n/g, '\n');
+			} else {
+				result[key] = variableValues[key];
 			}
 		}
-		onSave(variableValues);
+		onSave(result);
 		show = false;
 	};
 
@@ -102,20 +106,17 @@
 										<div class="flex mt-0.5 mb-0.5 space-x-2">
 											<div class=" flex-1">
 												{#if variables[variable]?.type === 'select'}
-													{@const options = variableAttributes?.options ?? []}
-													{@const placeholder = variableAttributes?.placeholder ?? ''}
-
 													<select
 														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30"
 														bind:value={variableValues[variable]}
 														id="input-variable-{idx}"
 													>
-														{#if placeholder}
+														{#if variables[variable]?.placeholder}
 															<option value="" disabled selected>
-																{placeholder}
+																{variables[variable].placeholder}
 															</option>
 														{/if}
-														{#each options as option}
+														{#each variables[variable]?.options ?? [] as option}
 															<option value={option} selected={option === variableValues[variable]}>
 																{option}
 															</option>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR merges the `dev` branch into `main`, introducing two focused improvements to `InputVariablesModal.svelte`:

- **Immutable submit handler**: The `submitHandler` now builds a fresh `result` object instead of mutating `variableValues` in-place, avoiding unintended Svelte reactive side-effects during the save operation.
- **Simplified `select` template**: Removes two redundant `@const` declarations inside the `select` block, replacing `variableAttributes?.options` / `variableAttributes?.placeholder` with direct `variables[variable]?.options` / `variables[variable]?.placeholder` accesses.

Both changes are functionally equivalent to the prior behaviour and improve code clarity.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are straightforward refactors with no logic regressions.

The PR contains only two small, well-reasoned improvements: avoiding Svelte reactive proxy mutation in the submit handler and removing two redundant template-local constants. Neither change alters observable behaviour. No P0/P1 issues were found.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/components/chat/MessageInput/InputVariablesModal.svelte | Refactors submitHandler to build an immutable result object instead of mutating the Svelte reactive proxy, and inlines `variables[variable]` accesses in the select template to remove redundant `@const` variables. Both changes are safe and correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User fills in variables]) --> B[User clicks Save]
    B --> C{submitHandler}
    C --> D[Create empty result object]
    D --> E{For each key in variableValues}
    E --> F{Is value a string?}
    F -- Yes --> G[Normalize CRLF: replace /\r\n/g with \n]
    G --> H[Assign to result key]
    F -- No --> I[Copy value as-is to result key]
    I --> H
    H --> E
    E -- Done --> J[onSave result]
    J --> K[show = false]
    K --> L([Modal closes])
```

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #47 from FPOscar/curs..."](https://github.com/fposcar/fpwebaiui/commit/bea1630ca567e9516f7e9249bdc383523623c68e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27740943)</sub>

<!-- /greptile_comment -->