### PR TITLE
Fix missing dependencies for startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-04-21
+
+### Fixed
+
+- 🐛 **Missing `aiosqlite` dependency.** Fixed a startup crash (`ModuleNotFoundError: No module named 'aiosqlite'`) when installing Open WebUI via `pip` or `uv` by adding the missing `aiosqlite` package to `pyproject.toml`. The dependency was listed in `requirements.txt` but not in the published package metadata, so it was not installed automatically. [#23916](https://github.com/open-webui/open-webui/issues/23916)
+- 🐛 **Missing `asyncpg` dependency.** Added the missing `asyncpg` package to `pyproject.toml` to prevent the same startup crash for PostgreSQL users. Like `aiosqlite`, it was present in `requirements.txt` but absent from the published package dependencies.
+
 ## [0.9.0] - 2026-04-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "open-webui",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "open-webui",
-			"version": "0.9.0",
+			"version": "0.9.1",
 			"dependencies": {
 				"@azure/msal-browser": "^4.5.0",
 				"@codemirror/lang-javascript": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "open-webui",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"private": true,
 	"scripts": {
 		"dev": "npm run pyodide:fetch && vite dev --host",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "python-mimeparse==2.0.0",
 
     "sqlalchemy==2.0.48",
+    "aiosqlite==0.21.0",
+    "asyncpg==0.30.0",
     "alembic==1.18.4",
     "peewee==3.19.0",
     "peewee-migrate==1.14.3",


### PR DESCRIPTION
Add `aiosqlite` and `asyncpg` to `pyproject.toml` to resolve startup crashes related to missing dependencies when installing Open WebUI. Update version to 0.9.1 in relevant files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch release adds `aiosqlite==0.21.0` and `asyncpg==0.30.0` to the published package metadata in `pyproject.toml`, fixing startup crashes for users who install Open WebUI via `pip` or `uv`. Both versions are already pinned identically in `requirements.txt` and `requirements-min.txt`, so the fix is internally consistent. The version bump to 0.9.1 is applied uniformly across `package.json` and `package-lock.json`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-scoped dependency fix with no logic changes.

The only code change is adding two pinned dependencies that already appear at the same versions in `requirements.txt` and `requirements-min.txt`. Version bump is consistent across all relevant files. No logic, schema, or behavioral changes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Added `aiosqlite==0.21.0` and `asyncpg==0.30.0` to core dependencies; versions match those pinned in `requirements.txt` and `requirements-min.txt`. |
| CHANGELOG.md | Added 0.9.1 changelog entry documenting both missing-dependency fixes with upstream issue reference. |
| package.json | Version bumped from 0.9.0 to 0.9.1; consistent with `package-lock.json` and the hatch version source. |
| package-lock.json | Version bumped from 0.9.0 to 0.9.1 in two places to match `package.json`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User: pip install open-webui] --> B{pyproject.toml\ndependencies resolved}
    B -->|Before fix| C[aiosqlite ❌ missing\nasyncpg ❌ missing]
    B -->|After fix| D[aiosqlite==0.21.0 ✅\nasyncpg==0.30.0 ✅]
    C --> E[ModuleNotFoundError\non startup]
    D --> F[SQLite async driver\nready]
    D --> G[PostgreSQL async driver\nready]
    F --> H[App starts successfully]
    G --> H
```

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;upstream/m..."](https://github.com/fposcar/fpwebaiui/commit/ab47bb77bf90ea6de4c5211afe2e1555dda47a13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29262651)</sub>

<!-- /greptile_comment -->