### PR TITLE
Add voice input button for dictation and update podcast generation button

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -78,6 +78,7 @@
 
 	import XMark from '../icons/XMark.svelte';
 	import GlobeAlt from '../icons/GlobeAlt.svelte';
+	import Headphone from '../icons/Headphone.svelte';
 	import Photo from '../icons/Photo.svelte';
 	import Wrench from '../icons/Wrench.svelte';
 	import Sparkles from '../icons/Sparkles.svelte';
@@ -1948,7 +1949,56 @@
 												<TerminalMenu bind:show={showTerminalMenu} />
 											{/if}
 
-										<!-- Podcast Gen -->
+											{#if $_user?.role === 'admin' || ($_user?.permissions?.chat?.stt ?? true)}
+												<!-- {$i18n.t('Record voice')} -->
+												<Tooltip content={$i18n.t('Dictate')}>
+													<button
+														id="voice-input-button"
+														class=" text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5 mr-0.5 self-center"
+														type="button"
+														on:click={async () => {
+															try {
+																let stream = await navigator.mediaDevices
+																	.getUserMedia({ audio: true })
+																	.catch(function (err) {
+																		toast.error(
+																			$i18n.t(
+																				`Permission denied when accessing microphone: {{error}}`,
+																				{
+																					error: err
+																				}
+																			)
+																		);
+																		return null;
+																	});
+
+																if (stream) {
+																	recording = true;
+																	const tracks = stream.getTracks();
+																	tracks.forEach((track) => track.stop());
+																}
+																stream = null;
+															} catch {
+																toast.error($i18n.t('Permission denied when accessing microphone'));
+															}
+														}}
+														aria-label={$i18n.t('Voice Input')}
+													>
+														<svg
+															xmlns="http://www.w3.org/2000/svg"
+															viewBox="0 0 20 20"
+															fill="currentColor"
+															class="w-5 h-5 translate-y-[0.5px]"
+														>
+															<path d="M7 4a3 3 0 016 0v6a3 3 0 11-6 0V4z" />
+															<path
+																d="M5.5 9.643a.75.75 0 00-1.5 0V10c0 3.06 2.29 5.585 5.25 5.954V17.5h-1.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-1.5v-1.546A6.001 6.001 0 0016 10v-.357a.75.75 0 00-1.5 0V10a4.5 4.5 0 01-9 0v-.357z"
+															/>
+														</svg>
+													</button>
+												</Tooltip>
+											{/if}
+
 											<Tooltip content="Podcast Gen">
 												<button
 													id="podcast-gen-button"
@@ -1961,17 +2011,7 @@
 													}}
 													aria-label="Podcast Gen"
 												>
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														viewBox="0 0 20 20"
-														fill="currentColor"
-														class="w-5 h-5 translate-y-[0.5px]"
-													>
-														<path d="M7 4a3 3 0 016 0v6a3 3 0 11-6 0V4z" />
-														<path
-															d="M5.5 9.643a.75.75 0 00-1.5 0V10c0 3.06 2.29 5.585 5.25 5.954V17.5h-1.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-1.5v-1.546A6.001 6.001 0 0016 10v-.357a.75.75 0 00-1.5 0V10a4.5 4.5 0 01-9 0v-.357z"
-														/>
-													</svg>
+													<Headphone className="size-5 translate-y-[0.5px]" />
 												</button>
 											</Tooltip>
 										{/if}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -218,6 +218,15 @@
 		loadingSpeech = false;
 	};
 
+	const handleSpeechEnded = (signal?: AbortSignal) => {
+		speaking = false;
+		speakingIdx = undefined;
+
+		if (!signal?.aborted && $settings.conversationMode) {
+			document.getElementById('voice-input-button')?.click();
+		}
+	};
+
 	// Resolve voice: model-specific > user settings > config default
 	const getVoiceId = () =>
 		model?.info?.meta?.tts?.voice ??
@@ -250,10 +259,7 @@
 					speech.rate = $settings.audio?.tts?.playbackRate ?? 1;
 
 					speech.onend = () => {
-						speaking = false;
-						if ($settings.conversationMode) {
-							document.getElementById('voice-input-button')?.click();
-						}
+						handleSpeechEnded(signal);
 					};
 
 					if (voice) {
@@ -266,9 +272,13 @@
 		} else {
 			$audioQueue.setId(`${message.id}`);
 			$audioQueue.setPlaybackRate($settings.audio?.tts?.playbackRate ?? 1);
-			$audioQueue.onStopped = () => {
-				speaking = false;
-				speakingIdx = undefined;
+			$audioQueue.onStopped = ({ event }) => {
+				if (event === 'empty-queue') {
+					handleSpeechEnded(signal);
+				} else {
+					speaking = false;
+					speakingIdx = undefined;
+				}
 			};
 
 			loadingSpeech = true;

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -251,10 +251,9 @@
 
 					speech.onend = () => {
 						speaking = false;
-						// Removed automatic voice input trigger - button is now for Podcast Gen
-						// if ($settings.conversationMode) {
-						// 	document.getElementById('voice-input-button')?.click();
-						// }
+						if ($settings.conversationMode) {
+							document.getElementById('voice-input-button')?.click();
+						}
 					};
 
 					if (voice) {


### PR DESCRIPTION
Introduce a voice input button for dictation, enhancing user interaction. Update the podcast generation button to use a new icon, improving the UI experience.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the voice-input-button for STT dictation and re-enables the `conversationMode` auto-trigger for both TTS paths — fixing a previously commented-out feature. The Podcast Gen button icon is updated from the old inline mic SVG to the `Headphone` component.

- **`ResponseMessage.svelte`**: Introduces `handleSpeechEnded` to consolidate post-speech cleanup logic; both the native browser TTS (`speech.onend`) and the custom TTS engine (`audioQueue.onStopped` with `empty-queue` event) now call it, correctly restoring the conversation-mode voice-input trigger for both paths.
- **`MessageInput.svelte`**: Adds a dedicated `voice-input-button` (guarded by the user's STT permission) that performs a microphone permission probe before setting `recording = true`, and swaps the Podcast Gen icon to `<Headphone />`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both TTS paths now correctly clean up state and re-trigger voice input in conversation mode, with the abort-signal guard preventing any double-trigger on manual stop.

The handleSpeechEnded refactor cleanly unifies speech-end handling. The audioQueue.onStopped callback now correctly differentiates empty-queue (natural end → trigger conversationMode) from stop/id-change (user-initiated → no trigger), and the abort-signal check closes the race between natural speech completion and manual cancellation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/components/chat/Messages/ResponseMessage.svelte | Adds handleSpeechEnded helper; both native and custom TTS paths now uniformly handle speech end, including the conversationMode trigger. The abort-signal guard correctly prevents re-triggering when audio is manually stopped. |
| src/lib/components/chat/MessageInput.svelte | Adds a dedicated voice-input-button with mic permission probe, guarded by STT permission check. Podcast Gen button icon updated to Headphone component. Logic is consistent with the existing button pattern used elsewhere in the codebase. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ResponseMessage
    participant BrowserTTS as Browser TTS (SpeechSynthesis)
    participant AudioQueue as Custom TTS (AudioQueue)
    participant VoiceBtn as voice-input-button

    User->>ResponseMessage: speak()
    ResponseMessage->>ResponseMessage: stopAudio() → abort old signal
    ResponseMessage->>ResponseMessage: new AbortController → signal

    alt Native TTS engine
        ResponseMessage->>BrowserTTS: speechSynthesis.speak(utterance)
        BrowserTTS-->>ResponseMessage: speech.onend
        ResponseMessage->>ResponseMessage: handleSpeechEnded(signal)
    else Custom TTS engine
        ResponseMessage->>AudioQueue: setId / setPlaybackRate / onStopped callback
        AudioQueue-->>ResponseMessage: "onStopped({ event: 'empty-queue' })"
        ResponseMessage->>ResponseMessage: handleSpeechEnded(signal)
        AudioQueue-->>ResponseMessage: "onStopped({ event: 'stop' | 'id-change' })"
        ResponseMessage->>ResponseMessage: "speaking=false, speakingIdx=undefined (no trigger)"
    end

    ResponseMessage->>ResponseMessage: signal.aborted? → skip if manually stopped
    ResponseMessage->>ResponseMessage: conversationMode enabled?
    ResponseMessage->>VoiceBtn: document.getElementById('voice-input-button')?.click()
    VoiceBtn->>VoiceBtn: getUserMedia() permission probe
    VoiceBtn->>VoiceBtn: "recording = true"
```

<sub>Reviews (3): Last reviewed commit: ["feat: enhance speech handling by adding ..."](https://github.com/fposcar/fpwebaiui/commit/83e5115ab162ed8cb37e226a80302beb6430acc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32142851)</sub>

<!-- /greptile_comment -->