### PR TITLE
Restore Findlay Park AI branding

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -17,7 +17,7 @@ def version_callback(value: bool) -> None:
     if value:
         from open_webui.env import VERSION
 
-        typer.echo(f'Open WebUI version: {VERSION}')
+        typer.echo(f'Findlay Park AI version: {VERSION}')
         raise typer.Exit()
 
 

--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -100,7 +100,7 @@ class ERROR_MESSAGES(str, Enum):
 
     FEATURE_DISABLED = lambda name='': f'{name} is disabled'
     INPUT_TOO_LONG = lambda size='': f'Input prompt exceeds maximum length of {size}'
-    SERVER_CONNECTION_ERROR = 'Open WebUI: Server Connection Error'
+    SERVER_CONNECTION_ERROR = 'Findlay Park AI: Server Connection Error'
     REQUIRED_FIELD_EMPTY = lambda name='': f'Required field {name} is empty'
     OAUTH_NOT_CONFIGURED = lambda name='': f"Provider '{name}' is not configured"
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -777,10 +777,6 @@ if LICENSE_PUBLIC_KEY:
 # WEBUI Identity
 ####################################
 
-WEBUI_NAME = os.getenv('WEBUI_NAME', 'Open WebUI')
-if WEBUI_NAME != 'Open WebUI':
-    WEBUI_NAME += ' (Open WebUI)'
-
 WEBUI_FAVICON_URL = 'https://openwebui.com/favicon.png'
 WEBUI_BUILD_HASH = os.getenv('WEBUI_BUILD_HASH', 'dev-build')
 TRUSTED_SIGNATURE_KEY = os.getenv('TRUSTED_SIGNATURE_KEY', '')

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -629,7 +629,7 @@ https://github.com/open-webui/open-webui
         print(banner)
     except UnicodeEncodeError:
         # Stdout can't encode the box-drawing banner (Windows cp1252, redirected/headless stdout); fall back to ASCII.
-        print(f'Open WebUI v{VERSION} - building the best AI user interface.\nhttps://github.com/open-webui/open-webui')
+        print(f'Findlay Park AI v{VERSION} - building the best AI user interface.\nhttps://github.com/open-webui/open-webui')
 
 
 @asynccontextmanager
@@ -747,7 +747,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title='Open WebUI',
+    title='Findlay Park AI',
     docs_url='/docs' if ENV == 'dev' else None,
     openapi_url='/openapi.json' if ENV == 'dev' else None,
     redoc_url=None,
@@ -2243,7 +2243,7 @@ async def generate_messages(
     pipeline, then converts the response back to Anthropic Messages format.
 
     Supports both streaming and non-streaming requests.
-    All models configured in Open WebUI are accessible via this endpoint.
+    All models configured in Findlay Park AI are accessible via this endpoint.
 
     Authentication: Supports both standard Authorization header and
     Anthropic's x-api-key header (via middleware translation).
@@ -2595,7 +2595,7 @@ async def get_app_changelog():
 @app.get('/api/usage')
 async def get_current_usage(user=Depends(get_verified_user)):
     """
-    Get current usage statistics for Open WebUI.
+    Get current usage statistics for Findlay Park AI.
     This is an experimental endpoint and subject to change.
     """
     try:

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -359,7 +359,7 @@ def load_speech_pipeline(request):
 async def _raise_tts_error(exc: Exception, r=None) -> None:
     """Raise a standardised HTTPException from a TTS provider failure."""
     code = r.status if r is not None else 500
-    detail = 'Open WebUI: Server Connection Error'
+    detail = 'Findlay Park AI: Server Connection Error'
     if r is not None:
         try:
             res = await r.json()
@@ -689,7 +689,7 @@ async def _transcribe_openai(request, file_path, filename, languages, file_dir, 
                     detail = f'External: {res["error"].get("message", "")}'
             except Exception:
                 detail = f'External: {e}'
-        raise Exception(detail if detail else 'Open WebUI: Server Connection Error')
+        raise Exception(detail if detail else 'Findlay Park AI: Server Connection Error')
 
 
 async def _transcribe_deepgram(request, file_path, languages, file_dir, id):
@@ -739,7 +739,7 @@ async def _transcribe_deepgram(request, file_path, languages, file_dir, id):
 
     except Exception as e:
         log.exception(e)
-        detail = 'Open WebUI: Server Connection Error'
+        detail = 'Findlay Park AI: Server Connection Error'
         if r is not None:
             try:
                 res = await r.json()
@@ -865,7 +865,7 @@ async def _transcribe_azure(request, file_path, filename, file_dir, id):
             detail = f'External: {e}'
         raise HTTPException(
             status_code=e.status if e.status else 500,
-            detail=detail if detail else 'Open WebUI: Server Connection Error',
+            detail=detail if detail else 'Findlay Park AI: Server Connection Error',
         )
 
 
@@ -1024,7 +1024,7 @@ async def _transcribe_mistral(request, file_path, filename, metadata, file_dir, 
             detail = f'External: {e}'
         raise HTTPException(
             status_code=e.status if e.status else 500,
-            detail=detail if detail else 'Open WebUI: Server Connection Error',
+            detail=detail if detail else 'Findlay Park AI: Server Connection Error',
         )
 
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -161,7 +161,7 @@ async def get_headers_and_cookies(
         **(
             {
                 'HTTP-Referer': 'https://openwebui.com/',
-                'X-Title': 'Open WebUI',
+                'X-Title': 'Findlay Park AI',
             }
             if 'openrouter.ai' in url
             else {}
@@ -352,7 +352,7 @@ async def speech(request: Request, user=Depends(get_verified_user)):
 
             raise HTTPException(
                 status_code=r.status if r else 500,
-                detail=detail if detail else 'Open WebUI: Server Connection Error',
+                detail=detail if detail else 'Findlay Park AI: Server Connection Error',
             )
 
     except ValueError:
@@ -644,7 +644,7 @@ async def get_models(request: Request, url_idx: int | None = None, user=Depends(
             except aiohttp.ClientError as e:
                 # ClientError covers all aiohttp requests issues
                 log.exception(f'Client error: {str(e)}')
-                raise HTTPException(status_code=500, detail='Open WebUI: Server Connection Error')
+                raise HTTPException(status_code=500, detail='Findlay Park AI: Server Connection Error')
             except Exception as e:
                 log.exception(f'Unexpected error: {e}')
                 error_detail = f'Unexpected error: {str(e)}'
@@ -1612,7 +1612,7 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
         log.exception(e)
         raise HTTPException(
             status_code=r.status if r else 500,
-            detail='Open WebUI: Server Connection Error',
+            detail='Findlay Park AI: Server Connection Error',
         )
     finally:
         if not streaming:

--- a/backend/open_webui/static/site.webmanifest
+++ b/backend/open_webui/static/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Open WebUI",
-  "short_name": "WebUI",
+  "name": "Findlay Park AI",
+  "short_name": "FP AI",
   "icons": [
     {
       "src": "/static/web-app-manifest-192x192.png",

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -550,7 +550,7 @@ async def _check_calendar_alerts(app) -> None:
 
         # Send webhook notification if user has one configured
         try:
-            webui_name = getattr(app.state, 'WEBUI_NAME', 'Open WebUI')
+            webui_name = getattr(app.state, 'WEBUI_NAME', 'Findlay Park AI')
             enable_user_webhooks = getattr(app.state.config, 'ENABLE_USER_WEBHOOKS', False)
 
             if enable_user_webhooks:

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -426,7 +426,7 @@ async def get_oauth_client_info_with_dynamic_client_registration(
         redirect_base_url = (str(request.app.state.config.WEBUI_URL or request.base_url)).rstrip('/')
 
         oauth_client_metadata = OAuthClientMetadata(
-            client_name='Open WebUI',
+            client_name='Findlay Park AI',
             redirect_uris=[f'{redirect_base_url}/oauth/clients/{client_id}/callback'],
             grant_types=['authorization_code', 'refresh_token'],
             response_types=['code'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-webui"
-description = "Open WebUI"
+description = "Findlay Park AI"
 authors = [
     { name = "Timothy Jaeryang Baek", email = "tim@openwebui.com" }
 ]

--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -487,7 +487,7 @@
 						</div>
 
 						<div class="mt-2 mb-1 text-xs text-gray-400 dark:text-gray-500">
-							{$i18n.t(`Open WebUI uses faster-whisper internally.`)}
+							{$i18n.t(`Findlay Park AI uses faster-whisper internally.`)}
 
 							<a
 								class=" hover:underline dark:text-gray-200 text-gray-800"
@@ -650,7 +650,7 @@
 								</div>
 							</div>
 							<div class="mt-2 mb-1 text-xs text-gray-400 dark:text-gray-500">
-								{$i18n.t(`Open WebUI uses SpeechT5 and CMU Arctic speaker embeddings.`)}
+								{$i18n.t(`Findlay Park AI uses SpeechT5 and CMU Arctic speaker embeddings.`)}
 
 								To learn more about SpeechT5,
 

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -206,7 +206,7 @@
 									{$i18n.t('Help')}
 								</div>
 								<div class=" text-xs text-gray-500">
-									{$i18n.t('Discover how to use Open WebUI and seek support from the community.')}
+									{$i18n.t('Discover how to use Findlay Park AI and seek support from the community.')}
 								</div>
 							</div>
 

--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -540,7 +540,7 @@
 >
 > It looks like you have over 50 users, that usually falls under organizational usage.
 > 
-> Open WebUI is completely free to use as-is, with no restrictions or hidden limits, and we'd love to keep it that way. 🌱  
+> Findlay Park AI is completely free to use as-is, with no restrictions or hidden limits, and we'd love to keep it that way. 🌱
 >
 > By supporting the project through sponsorship or an enterprise license, you’re not only helping us stay independent, you’re also helping us ship new features faster, improve stability, and grow the project for the long haul. With an *enterprise license*, you also get additional perks like dedicated support, customization options, and more, all at a fraction of what it would cost to build and maintain internally.  
 > 

--- a/src/lib/components/channel/Channel.svelte
+++ b/src/lib/components/channel/Channel.svelte
@@ -12,7 +12,8 @@
 		channelId as _channelId,
 		showSidebar,
 		socket,
-		user
+		user,
+		WEBUI_NAME
 	} from '$lib/stores';
 	import { getChannelById, getChannelMessages, sendMessage } from '$lib/apis/channels';
 
@@ -288,10 +289,10 @@
 					} else {
 						return e.name;
 					}
-				}, '')} • Open WebUI</title
+				}, '')} • {$WEBUI_NAME}</title
 		>
 	{:else}
-		<title>#{channel?.name ?? 'Channel'} • Open WebUI</title>
+		<title>#{channel?.name ?? 'Channel'} • {$WEBUI_NAME}</title>
 	{/if}
 </svelte:head>
 

--- a/src/lib/components/chat/Settings/About.svelte
+++ b/src/lib/components/chat/Settings/About.svelte
@@ -114,7 +114,7 @@
 
 		{#if $config?.license_metadata}
 			<div class="mb-2 text-xs">
-				{#if !$WEBUI_NAME.includes('Open WebUI')}
+				{#if !$WEBUI_NAME.includes('Findlay Park AI')}
 					<span class=" text-gray-500 dark:text-gray-300 font-medium">{$WEBUI_NAME}</span> -
 				{/if}
 
@@ -158,7 +158,7 @@
 				class="text-xs text-gray-400 dark:text-gray-500">{new Date().getFullYear()} <a
 					href="https://findlaypark.com"
 					target="_blank"
-					class="underline">Open WebUI Inc.</a
+					class="underline">Findlay Park</a
 				> <a href="https://github.com/open-webui/open-webui/blob/main/LICENSE" target="_blank"
 					>All rights reserved.</a
 				>

--- a/src/lib/components/chat/Settings/Connections.svelte
+++ b/src/lib/components/chat/Settings/Connections.svelte
@@ -136,7 +136,7 @@
 							{$i18n.t('Connect to your own OpenAI compatible API endpoints.')}
 							<br />
 							{$i18n.t(
-								'CORS must be properly configured by the provider to allow requests from Open WebUI.'
+								'CORS must be properly configured by the provider to allow requests from Findlay Park AI.'
 							)}
 						</div>
 					</div>

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -270,7 +270,7 @@
 						href="https://github.com/open-webui/open-webui/blob/main/docs/CONTRIBUTING.md#-translations-and-internationalization"
 						target="_blank"
 					>
-						Help us translate Open WebUI!
+						Help us translate Findlay Park AI!
 					</a>
 				</div>
 			{/if}

--- a/src/lib/components/chat/Settings/Integrations.svelte
+++ b/src/lib/components/chat/Settings/Integrations.svelte
@@ -122,7 +122,7 @@
 							{$i18n.t('Connect to your own OpenAPI compatible external tool servers.')}
 							<br />
 							{$i18n.t(
-								'CORS must be properly configured by the provider to allow requests from Open WebUI.'
+								'CORS must be properly configured by the provider to allow requests from Findlay Park AI.'
 							)}
 						</div>
 					</div>

--- a/src/lib/components/chat/ToolServersModal.svelte
+++ b/src/lib/components/chat/ToolServersModal.svelte
@@ -75,7 +75,7 @@
 
 			<div class="px-5 pb-5 w-full flex flex-col justify-center">
 				<div class=" text-xs text-gray-600 dark:text-gray-300 mb-2">
-					{$i18n.t('Open WebUI can use tools provided by any OpenAPI server.')} <br /><a
+					{$i18n.t('Findlay Park AI can use tools provided by any OpenAPI server.')} <br /><a
 						class="underline"
 						href="https://github.com/open-webui/openapi-servers"
 						target="_blank">{$i18n.t('Learn more about OpenAPI tool servers.')}</a

--- a/src/routes/(app)/admin/functions/create/+page.svelte
+++ b/src/routes/(app)/admin/functions/create/+page.svelte
@@ -24,7 +24,7 @@
 			console.log('Version is lower than required');
 			toast.error(
 				$i18n.t(
-					'Open WebUI version (v{{OPEN_WEBUI_VERSION}}) is lower than required version (v{{REQUIRED_VERSION}})',
+					'Findlay Park AI version (v{{OPEN_WEBUI_VERSION}}) is lower than required version (v{{REQUIRED_VERSION}})',
 					{
 						OPEN_WEBUI_VERSION: WEBUI_VERSION,
 						REQUIRED_VERSION: manifest?.required_open_webui_version ?? '0.0.0'

--- a/src/routes/(app)/admin/functions/edit/+page.svelte
+++ b/src/routes/(app)/admin/functions/edit/+page.svelte
@@ -25,7 +25,7 @@
 			console.log('Version is lower than required');
 			toast.error(
 				$i18n.t(
-					'Open WebUI version (v{{OPEN_WEBUI_VERSION}}) is lower than required version (v{{REQUIRED_VERSION}})',
+					'Findlay Park AI version (v{{OPEN_WEBUI_VERSION}}) is lower than required version (v{{REQUIRED_VERSION}})',
 					{
 						OPEN_WEBUI_VERSION: WEBUI_VERSION,
 						REQUIRED_VERSION: manifest?.required_open_webui_version ?? '0.0.0'

--- a/src/routes/(app)/workspace/tools/create/+page.svelte
+++ b/src/routes/(app)/workspace/tools/create/+page.svelte
@@ -22,7 +22,7 @@
 			console.log('Version is lower than required');
 			toast.error(
 				$i18n.t(
-					'Open WebUI version (v{{OPEN_WEBUI_VERSION}}) is lower than required version (v{{REQUIRED_VERSION}})',
+					'Findlay Park AI version (v{{OPEN_WEBUI_VERSION}}) is lower than required version (v{{REQUIRED_VERSION}})',
 					{
 						OPEN_WEBUI_VERSION: WEBUI_VERSION,
 						REQUIRED_VERSION: manifest?.required_open_webui_version ?? '0.0.0'

--- a/src/routes/(app)/workspace/tools/edit/+page.svelte
+++ b/src/routes/(app)/workspace/tools/edit/+page.svelte
@@ -22,7 +22,7 @@
 			console.log('Version is lower than required');
 			toast.error(
 				$i18n.t(
-					'Open WebUI version (v{{OPEN_WEBUI_VERSION}}) is lower than required version (v{{REQUIRED_VERSION}})',
+					'Findlay Park AI version (v{{OPEN_WEBUI_VERSION}}) is lower than required version (v{{REQUIRED_VERSION}})',
 					{
 						OPEN_WEBUI_VERSION: WEBUI_VERSION,
 						REQUIRED_VERSION: manifest?.required_open_webui_version ?? '0.0.0'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -498,7 +498,7 @@
 
 			if ($isLastActiveTab) {
 				if ($settings?.notificationEnabled ?? false) {
-					new Notification(`${data.title} • Open WebUI`, {
+					new Notification(`${data.title} • ${$WEBUI_NAME}`, {
 						body: timeStr,
 						icon: `${WEBUI_BASE_URL}/static/favicon.png`
 					});
@@ -629,7 +629,7 @@
 
 					if ($isLastActiveTab) {
 						if ($settings?.notificationEnabled ?? false) {
-							new Notification(`${displayTitle} • Open WebUI`, {
+							new Notification(`${displayTitle} • ${$WEBUI_NAME}`, {
 								body: content,
 								icon: `${WEBUI_BASE_URL}/static/favicon.png`
 							});
@@ -737,7 +737,7 @@
 
 				if ($isLastActiveTab) {
 					if ($settings?.notificationEnabled ?? false) {
-						new Notification(`${title} • Open WebUI`, {
+						new Notification(`${title} • ${$WEBUI_NAME}`, {
 							body: data?.content,
 							icon: `${WEBUI_API_BASE_URL}/users/${data?.user?.id}/profile/image`
 						});

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,6 +1,6 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-<ShortName>Open WebUI</ShortName>
-<Description>Search Open WebUI</Description>
+<ShortName>Findlay Park AI</ShortName>
+<Description>Search Findlay Park AI</Description>
 <InputEncoding>UTF-8</InputEncoding>
 <Image width="16" height="16" type="image/x-icon">http://localhost:5137/favicon.png</Image>
 <Url type="text/html" method="get" template="http://localhost:5137/?q={searchTerms}"/>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Restore the default runtime app name to Findlay Park AI by removing the duplicate upstream WEBUI_NAME override.
- Replace hardcoded user-facing Open WebUI branding in notifications, settings/help copy, manifests, server errors, API metadata, and package description.

### Walkthrough
[findlay_branding_preview_smoke.mp4](https://cursor.com/agents/bc-011a4299-7ac2-4eaa-8f3c-113bb809d741/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffindlay_branding_preview_smoke.mp4)
[Findlay Park AI branding preview](https://cursor.com/agents/bc-011a4299-7ac2-4eaa-8f3c-113bb809d741/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffindlay_branding_preview.webp)

### Validation
- `WEBUI_SECRET_KEY=test-secret-key PYTHONPATH=backend python3 ...` confirmed backend default `WEBUI_NAME` resolves to `Findlay Park AI`.
- Critical branding assertion script confirmed app-name fallbacks no longer hardcode `Open WebUI` in the runtime branding files.
- `python3 -m py_compile ...` passed for modified Python files.
- `npm run test:frontend` passed; no frontend test files are present.
- `npm run build` passed and produced the static site.
- `npm run check` still fails due to existing broad repo type/a11y issues unrelated to this change (9,630 errors across 383 files); sample failures include implicit-any diagnostics and missing `@types/uuid`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-011a4299-7ac2-4eaa-8f3c-113bb809d741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-011a4299-7ac2-4eaa-8f3c-113bb809d741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces hardcoded \"Open WebUI\" branding with \"Findlay Park AI\" across backend Python modules, frontend Svelte components, manifests, and configuration files. The core fix removes a duplicate `WEBUI_NAME` env-var override that was shadowing the earlier \"Findlay Park AI\" default already defined in `env.py`.

- **Backend**: Updates FastAPI title, startup banner, error message strings, OAuth client name, OpenRouter `X-Title` header, and API docstrings.
- **Frontend**: Switches three notification `Notification()` calls and channel page titles to the reactive `$WEBUI_NAME` store (correct); replaces remaining in-component strings with the hardcoded fork name.
- **Manifests / XML**: Updates `site.webmanifest`, `static/opensearch.xml`, and `pyproject.toml` descriptions.

<h3>Confidence Score: 3/5</h3>

Safe to merge for all runtime behavior; one content issue in the admin user list needs attention before shipping to real admins.

The env.py duplicate removal and the notification/title reactive-store fixes are correct. The problematic spot is the 50-user admin banner in UserList.svelte: the opening sentence now names 'Findlay Park AI' but the body, enterprise-license link (docs.openwebui.com/enterprise), and sponsor link (github.com/sponsors/tjbck) all refer to the upstream Open WebUI project. An admin who reads this could try to purchase an enterprise license thinking it's for Findlay Park AI and land on an unrelated vendor's page.

src/lib/components/admin/Users/UserList.svelte — the enterprise/sponsorship callout mixes Findlay Park AI branding with Open WebUI support links.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| backend/open_webui/env.py | Removes the duplicate downstream WEBUI_NAME override ('Open WebUI') that shadowed the earlier 'Findlay Park AI' default already present at line 129; clean and correct. |
| src/lib/components/admin/Users/UserList.svelte | Renames the product in the 50-user sponsorship banner but leaves enterprise/sponsor links pointing to the upstream Open WebUI project, creating an incoherent message for admins. |
| backend/open_webui/routers/openai.py | Updates X-Title to 'Findlay Park AI' for OpenRouter requests but leaves HTTP-Referer as openwebui.com; minor inconsistency in attribution headers. |
| src/lib/components/channel/Channel.svelte | Switches hardcoded 'Open WebUI' in page titles to the reactive $WEBUI_NAME store — correctly dynamic. |
| src/routes/+layout.svelte | Replaces three hardcoded 'Open WebUI' notification titles with $WEBUI_NAME — correctly uses the store. |
| backend/open_webui/main.py | Renames FastAPI app title, startup banner, and two docstring references from Open WebUI to Findlay Park AI; no logic changes. |
| backend/open_webui/static/site.webmanifest | Updates PWA manifest name and short_name to 'Findlay Park AI' / 'FP AI'; straightforward. |
| backend/open_webui/utils/oauth.py | Updates OAuth dynamic client registration client_name from 'Open WebUI' to 'Findlay Park AI'; no functional change. |
| src/lib/components/chat/Settings/About.svelte | Changes the license display guard from checking for 'Open WebUI' to 'Findlay Park AI' and updates the copyright link; consistent with branding goal. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["env.py: WEBUI_NAME\ndefault = Findlay Park AI"] --> B["main.py: app.state.WEBUI_NAME"]
    B --> C["/api/config response\nname field"]
    B --> D["Dynamic opensearch.xml"]
    B --> E["Dynamic webmanifest"]
    F["static/site.webmanifest\nFindlay Park AI"] -.->|"static fallback"| E
    G["Frontend $WEBUI_NAME store"] -->|"loaded from /api/config"| C
    G --> H["layout.svelte\nNotification titles"]
    G --> I["Channel.svelte\npage titles"]
    J["Hardcoded strings\nAudio, Connections, General, etc"] --> K["UI labels via i18n"]
    L["openai.py: OpenRouter headers\nX-Title = Findlay Park AI\nHTTP-Referer = openwebui.com"] --> M["OpenRouter API requests"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/components/admin/Users/UserList.svelte`, line 543-551 ([link](https://github.com/fposcar/fpwebaiui/blob/fbbdb02558ab8236ec69ef54146a430e7690b818/src/lib/components/admin/Users/UserList.svelte#L543-L551)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Misleading enterprise branding after rename**

   The first sentence now attributes the product to "Findlay Park AI", but the rest of the message (the sponsor/enterprise CTA, "helping us stay independent", `docs.openwebui.com/enterprise`, and `github.com/sponsors/tjbck`) still refers to the upstream Open WebUI project and its author. An admin who reads "Findlay Park AI is completely free to use…" and clicks through to buy an enterprise license will land on the Open WebUI enterprise page, which is incoherent. Either update the links and pronouns to reflect this fork's actual support offering, or revert the first sentence so the full message stays consistent with the upstream project it redirects users to.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Restore Findlay Park AI branding"](https://github.com/fposcar/fpwebaiui/commit/fbbdb02558ab8236ec69ef54146a430e7690b818) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35345597)</sub>

<!-- /greptile_comment -->