### PR TITLE
Fix Docker frontend build memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,23 +27,17 @@ ARG GID=0
 FROM --platform=$BUILDPLATFORM node:22-alpine3.20 AS build
 ARG BUILD_HASH
 
-# Set Node.js options (heap limit Allocation failed - JavaScript heap out of memory)
-# ENV NODE_OPTIONS="--max-old-space-size=4096"
-
 WORKDIR /app
 
 # to store git revision in build
 RUN apk add --no-cache git
-
-# Set Node.js memory limit
-ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 COPY package.json package-lock.json ./
 RUN npm ci --force
 
 COPY . .
 ENV APP_BUILD_HASH=${BUILD_HASH}
-RUN npm run build
+RUN NODE_OPTIONS="--max-old-space-size=6144" npm run build
 
 ######## WebUI backend ########
 FROM python:3.11-slim-bookworm AS base


### PR DESCRIPTION
## What changed

- Raise the Node.js heap limit from 4 GB to 6 GB for the frontend production build.
- Scope `NODE_OPTIONS` to `npm run build` instead of applying it across the entire frontend build stage.
- Leave `.github/workflows/docker-image.yml` unchanged; it remains the repository's only GitHub Actions workflow.

## Why

The Docker Image CI run for merge commit `5f604167a078c0c5c131436efb006118057acf5d` authenticated to ACR successfully, but the Docker build failed while Vite was rendering chunks with `FATAL ERROR: Ineffective mark-compacts near heap limit` at the existing 4 GB Node heap limit. The image push was consequently skipped.

Failed run: https://github.com/FPOscar/FPWebAIUI/actions/runs/30796345499

## Validation

- `NODE_OPTIONS=--max-old-space-size=6144 npm exec vite build` — passed; transformed all 6,355 client modules and rendered production chunks.
- `git diff --cached --check` — passed.
- Confirmed the PR changes only `Dockerfile`.

A full local Docker build was not available because Docker is not installed in this workspace. The Docker Image CI workflow triggers only on pushes to `main`, so its definitive container-build verification will occur after merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the frontend production build’s Node.js heap ceiling from 4 GiB to 6 GiB while limiting the override to the build command.
- Removes the build-stage-wide `NODE_OPTIONS` environment variable.
- Applies `--max-old-space-size=6144` directly to `npm run build`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the heap-limit change narrowly scoped to the frontend production build.

The build command and its child processes inherit the 6 GiB heap ceiling, while unrelated frontend-stage commands revert to normal Node.js defaults without evidence of a resulting failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Dockerfile | Scopes the increased Node.js heap allowance to the frontend production build; no concrete defect was identified. |

<sub>Reviews (1): Last reviewed commit: ["Fix Docker frontend build memory"](https://github.com/fposcar/fpwebaiui/commit/b0b6298b3c566e9b8d204f30d8a59ad239cdda5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49628785)</sub>

<!-- /greptile_comment -->