### PR TITLE
Automate Azure production deployment

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,26 +1,143 @@
-name: Docker Image CI
+name: Build and deploy FPWebUI to Azure
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fpwebui-production
+  cancel-in-progress: false
+
+env:
+  AZURE_RESOURCE_GROUP: RG_AI-Dev
+  AZURE_CONTAINER_APP: fpwebui-egress
+  AZURE_CONTAINER_REGISTRY: fpwebuicontainers
+  AZURE_CONTAINER_REGISTRY_SERVER: fpwebuicontainers.azurecr.io
+  IMAGE_REPOSITORY: fpwebui
+  APP_URL: https://fpwebui-egress.greenflower-703134aa.uksouth.azurecontainerapps.io
 
 jobs:
-  build-and-push:
+  deploy:
+    name: Build and deploy production
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Check out deploy source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Sign in to Azure with GitHub OIDC
+        uses: azure/login@8216e11d8cd9b42fe925c852af8e76311ff067ac # v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Record the current production image
+        id: current
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_image="$(az containerapp show \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_CONTAINER_APP" \
+            --query 'properties.template.containers[0].image' \
+            --output tsv)"
+          test -n "$current_image"
+          echo "image=$current_image" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Azure Container Registry
-        run: echo "${{ secrets.ACR_PASSWORD }}" | docker login ${{ secrets.ACR_LOGIN_SERVER }} -u ${{ secrets.ACR_USERNAME }} --password-stdin
-
-      - name: Build Docker image
+        shell: bash
         run: |
-          IMAGE=${{ secrets.ACR_LOGIN_SERVER }}/fpwebui:${{ github.sha }}
-          docker build . -t $IMAGE
+          set -euo pipefail
+          az acr login --name "$AZURE_CONTAINER_REGISTRY"
 
-      - name: Push Docker image
+      - name: Build and push an immutable image
+        shell: bash
         run: |
-          IMAGE=${{ secrets.ACR_LOGIN_SERVER }}/fpwebui:${{ github.sha }}
-          docker push $IMAGE
+          set -euo pipefail
+          deploy_image="$AZURE_CONTAINER_REGISTRY_SERVER/$IMAGE_REPOSITORY:$GITHUB_SHA"
+          docker build --tag "$deploy_image" .
+          docker push "$deploy_image"
+          echo "DEPLOY_IMAGE=$deploy_image" >> "$GITHUB_ENV"
+
+      - name: Deploy the new Container App revision
+        id: deploy
+        shell: bash
+        run: |
+          set -euo pipefail
+          az containerapp update \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_CONTAINER_APP" \
+            --image "$DEPLOY_IMAGE" \
+            --output none
+
+      - name: Verify the live revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          ready_image=""
+          ready_revision=""
+
+          for attempt in $(seq 1 60); do
+            ready_revision="$(az containerapp show \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_CONTAINER_APP" \
+              --query 'properties.latestReadyRevisionName' \
+              --output tsv)"
+
+            if [ -n "$ready_revision" ]; then
+              ready_image="$(az containerapp revision show \
+                --resource-group "$AZURE_RESOURCE_GROUP" \
+                --name "$AZURE_CONTAINER_APP" \
+                --revision "$ready_revision" \
+                --query 'properties.template.containers[0].image' \
+                --output tsv)"
+            fi
+
+            if [ "$ready_image" = "$DEPLOY_IMAGE" ]; then
+              break
+            fi
+
+            sleep 10
+          done
+
+          if [ "$ready_image" != "$DEPLOY_IMAGE" ]; then
+            echo "The new image did not become the ready revision." >&2
+            exit 1
+          fi
+
+          curl --fail --silent --show-error \
+            --retry 12 \
+            --retry-delay 5 \
+            --retry-all-errors \
+            "$APP_URL/health"
+
+          {
+            echo "### Azure deployment"
+            echo "- Revision: \`$ready_revision\`"
+            echo "- Image: \`$DEPLOY_IMAGE\`"
+            echo "- Health: passed"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Roll back the image after a failed live verification
+        if: failure() && steps.deploy.outcome == 'success'
+        shell: bash
+        run: |
+          previous_image="${{ steps.current.outputs.image }}"
+          if [ -n "$previous_image" ]; then
+            echo "Rolling back to $previous_image"
+            az containerapp update \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_CONTAINER_APP" \
+              --image "$previous_image" \
+              --output none
+          fi


### PR DESCRIPTION
## What changed

- build and push immutable commit-SHA images to Azure Container Registry using GitHub OIDC
- deploy the image to the `fpwebui-egress` Azure Container App after pushes to `main`
- serialize production deployments, verify the ready revision and `/health`, and roll back after failed live verification
- add a manual workflow trigger for controlled reruns

## Why

The existing workflow stopped after publishing the container image, so production remained on the previous Container App revision. This completes the delivery path while avoiding long-lived Azure registry credentials.

## Validation

- parsed the workflow YAML and checked its deployment structure
- ran Prettier validation
- ran `git diff --check`
- verified the GitHub OIDC identity, repository variables, `AcrPush`, and scoped `Container Apps Contributor` role assignment
- verified the live application health endpoint is `/health`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the existing image-publishing workflow into a serialized Azure Container Apps production deployment using GitHub OIDC and immutable commit-SHA images.
- Records the current image for rollback.
- Builds and pushes the selected commit to Azure Container Registry.
- Deploys the image, waits for its revision to become ready, and checks `/health`.
- Attempts an image rollback when live verification fails.
- Adds a manual trigger, although it does not enforce that controlled reruns use `main`.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after considering one non-blocking hardening improvement: constrain manual production reruns to the main branch.

The automated main-branch deployment is serialized and includes revision and health verification with rollback, but manual dispatch currently checks out and deploys whichever ref the operator selects unless external Azure identity policy rejects it.

**Files Needing Attention:** .github/workflows/docker-image.yml

<details open><summary><h3>Security Review</h3></summary>

The manual trigger permits selecting a non-main ref without a workflow-level ref guard. Azure OIDC restrictions may prevent deployment, but the workflow itself does not enforce its trusted-source boundary.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-image.yml | Adds the complete Azure build, deployment, verification, and rollback pipeline; the manual trigger should explicitly restrict production reruns to main. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor Operator
    participant GH as GitHub Actions
    participant Azure as Azure OIDC
    participant ACR as Container Registry
    participant ACA as Container App
    Operator->>GH: Push main or manually dispatch selected ref
    GH->>GH: Checkout selected source
    GH->>Azure: Authenticate using OIDC
    GH->>ACA: Read current image
    GH->>ACR: Build and push commit-SHA image
    GH->>ACA: Update application image
    loop Until ready
        GH->>ACA: Query latest ready revision and image
    end
    GH->>ACA: Request shared /health endpoint
    alt Verification fails
        GH->>ACA: Update application to previous image
    end
```

<sub>Reviews (1): Last reviewed commit: ["Automate Azure production deployment"](https://github.com/fposcar/fpwebaiui/commit/99c78b4c20db2f7b8eb9bb068716cae9e74c4d06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50838201)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->