### PR TITLE
Support public OAuth clients for MCP servers

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -26,6 +26,10 @@ from open_webui.utils.oauth import (
     recover_static_oauth_client_metadata,
     resolve_oauth_client_info,
 )
+from open_webui.utils.oauth_registration import (
+    resolve_static_oauth_client_id,
+    uses_static_oauth_registration,
+)
 from open_webui.utils.tools import (
     bearer_auth_header,
     get_tool_server_data,
@@ -164,6 +168,7 @@ class OAuthClientRegistrationForm(BaseModel):
     url: str
     client_id: str
     client_name: str | None = None
+    oauth_client_id: str | None = None
     client_secret: str | None = None
     oauth_server_url: str | None = None
     oauth_scope: str | None = None
@@ -183,13 +188,19 @@ async def register_oauth_client(
 
         oauth_server_url = form_data.oauth_server_url if form_data.oauth_server_url else form_data.url
 
-        if form_data.client_secret:
+        if uses_static_oauth_registration(
+            oauth_client_id=form_data.oauth_client_id,
+            client_secret=form_data.client_secret,
+        ):
             # Static credentials: skip dynamic registration, build from provided credentials
             oauth_client_info = await get_oauth_client_info_with_static_credentials(
                 request,
                 oauth_client_id,
                 oauth_server_url,
-                oauth_client_id=form_data.client_id,
+                oauth_client_id=resolve_static_oauth_client_id(
+                    connection_id=form_data.client_id,
+                    oauth_client_id=form_data.oauth_client_id,
+                ),
                 oauth_client_secret=form_data.client_secret,
                 oauth_scope=form_data.oauth_scope,
             )

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -88,7 +88,10 @@ from open_webui.retrieval.web.utils import get_ssrf_safe_session, validate_url
 from open_webui.utils.auth import create_token, get_password_hash
 from open_webui.utils.groups import apply_default_group_assignment
 from open_webui.utils.misc import parse_duration
-from open_webui.utils.oauth_registration import select_static_token_endpoint_auth_method
+from open_webui.utils.oauth_registration import (
+    overlay_static_oauth_credentials,
+    select_static_token_endpoint_auth_method,
+)
 from open_webui.utils.validate import validate_profile_image_url
 from starlette.responses import RedirectResponse
 
@@ -719,14 +722,11 @@ def resolve_oauth_client_info(connection: dict) -> dict:
     data = decrypt_data(info.get('oauth_client_info', ''))
 
     if connection.get('auth_type') == 'oauth_2.1_static':
-        if info.get('oauth_client_id'):
-            data['client_id'] = info['oauth_client_id']
-
-        if info.get('oauth_client_secret'):
-            data['client_secret'] = info['oauth_client_secret']
-        elif info.get('oauth_client_id'):
-            data['client_secret'] = None
-            data['token_endpoint_auth_method'] = 'none'
+        data = overlay_static_oauth_credentials(
+            client_data=data,
+            oauth_client_id=info.get('oauth_client_id'),
+            oauth_client_secret=info.get('oauth_client_secret'),
+        )
 
     return data
 

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -88,6 +88,7 @@ from open_webui.retrieval.web.utils import get_ssrf_safe_session, validate_url
 from open_webui.utils.auth import create_token, get_password_hash
 from open_webui.utils.groups import apply_default_group_assignment
 from open_webui.utils.misc import parse_duration
+from open_webui.utils.oauth_registration import select_static_token_endpoint_auth_method
 from open_webui.utils.validate import validate_profile_image_url
 from starlette.responses import RedirectResponse
 
@@ -635,7 +636,7 @@ async def get_oauth_client_info_with_static_credentials(
     client_id: str,
     oauth_server_url: str,
     oauth_client_id: str,
-    oauth_client_secret: str,
+    oauth_client_secret: str | None,
     oauth_scope: str | None = None,
 ) -> OAuthClientInformationFull:
     """
@@ -675,18 +676,19 @@ async def get_oauth_client_info_with_static_credentials(
             ' '.join(resource_metadata.scopes_supported) if resource_metadata.scopes_supported else None
         )
 
-        # Determine token_endpoint_auth_method
-        token_endpoint_auth_method = 'client_secret_post'
-        if (
-            oauth_server_metadata
-            and oauth_server_metadata.token_endpoint_auth_methods_supported
-            and token_endpoint_auth_method not in oauth_server_metadata.token_endpoint_auth_methods_supported
-        ):
-            token_endpoint_auth_method = oauth_server_metadata.token_endpoint_auth_methods_supported[0]
+        client_secret = oauth_client_secret or None
+        token_endpoint_auth_method = select_static_token_endpoint_auth_method(
+            client_secret=client_secret,
+            supported_methods=(
+                oauth_server_metadata.token_endpoint_auth_methods_supported
+                if oauth_server_metadata
+                else None
+            ),
+        )
 
         oauth_client_info = OAuthClientInformationFull(
             client_id=oauth_client_id,
-            client_secret=oauth_client_secret,
+            client_secret=client_secret,
             redirect_uris=[redirect_uri],
             grant_types=['authorization_code', 'refresh_token'],
             response_types=['code'],
@@ -717,9 +719,14 @@ def resolve_oauth_client_info(connection: dict) -> dict:
     data = decrypt_data(info.get('oauth_client_info', ''))
 
     if connection.get('auth_type') == 'oauth_2.1_static':
-        if info.get('oauth_client_id') and info.get('oauth_client_secret'):
+        if info.get('oauth_client_id'):
             data['client_id'] = info['oauth_client_id']
+
+        if info.get('oauth_client_secret'):
             data['client_secret'] = info['oauth_client_secret']
+        elif info.get('oauth_client_id'):
+            data['client_secret'] = None
+            data['token_endpoint_auth_method'] = 'none'
 
     return data
 

--- a/backend/open_webui/utils/oauth_registration.py
+++ b/backend/open_webui/utils/oauth_registration.py
@@ -44,11 +44,14 @@ def select_static_token_endpoint_auth_method(
         return 'none'
 
     preferred_method: TokenEndpointAuthMethod = 'client_secret_post'
-    if not supported_methods or preferred_method in supported_methods:
+    if supported_methods is None or preferred_method in supported_methods:
         return preferred_method
 
-    for method in ('client_secret_basic', 'client_secret_post'):
-        if method in supported_methods:
-            return method
+    if 'client_secret_basic' in supported_methods:
+        return 'client_secret_basic'
 
-    return preferred_method
+    advertised_methods = ', '.join(supported_methods) or 'none'
+    raise ValueError(
+        'Authorization server does not advertise a supported client-secret '
+        f'token endpoint authentication method (advertised: {advertised_methods})'
+    )

--- a/backend/open_webui/utils/oauth_registration.py
+++ b/backend/open_webui/utils/oauth_registration.py
@@ -1,0 +1,38 @@
+from typing import Literal, Sequence
+
+
+TokenEndpointAuthMethod = Literal[
+    'none', 'client_secret_basic', 'client_secret_post'
+]
+
+
+def uses_static_oauth_registration(
+    *, oauth_client_id: str | None, client_secret: str | None
+) -> bool:
+    """Return whether supplied credentials describe a pre-registered OAuth client."""
+    return bool(oauth_client_id or client_secret)
+
+
+def resolve_static_oauth_client_id(
+    *, connection_id: str, oauth_client_id: str | None
+) -> str:
+    """Use the provider-issued client ID, retaining compatibility with legacy requests."""
+    return oauth_client_id or connection_id
+
+
+def select_static_token_endpoint_auth_method(
+    *, client_secret: str | None, supported_methods: Sequence[str] | None = None
+) -> TokenEndpointAuthMethod:
+    """Select token authentication for public or confidential static clients."""
+    if not client_secret:
+        return 'none'
+
+    preferred_method: TokenEndpointAuthMethod = 'client_secret_post'
+    if not supported_methods or preferred_method in supported_methods:
+        return preferred_method
+
+    for method in ('client_secret_basic', 'client_secret_post'):
+        if method in supported_methods:
+            return method
+
+    return preferred_method

--- a/backend/open_webui/utils/oauth_registration.py
+++ b/backend/open_webui/utils/oauth_registration.py
@@ -20,6 +20,22 @@ def resolve_static_oauth_client_id(
     return oauth_client_id or connection_id
 
 
+def overlay_static_oauth_credentials(
+    *,
+    client_data: dict,
+    oauth_client_id: str | None,
+    oauth_client_secret: str | None,
+) -> dict:
+    """Overlay explicitly stored credentials without erasing encrypted values."""
+    if oauth_client_id:
+        client_data['client_id'] = oauth_client_id
+
+    if oauth_client_secret:
+        client_data['client_secret'] = oauth_client_secret
+
+    return client_data
+
+
 def select_static_token_endpoint_auth_method(
     *, client_secret: str | None, supported_methods: Sequence[str] | None = None
 ) -> TokenEndpointAuthMethod:

--- a/backend/tests/test_oauth_registration.py
+++ b/backend/tests/test_oauth_registration.py
@@ -1,3 +1,5 @@
+import pytest
+
 from open_webui.utils.oauth_registration import (
     overlay_static_oauth_credentials,
     resolve_static_oauth_client_id,
@@ -110,3 +112,14 @@ def test_confidential_client_prefers_post_and_can_fall_back_to_basic():
         )
         == 'client_secret_basic'
     )
+
+
+def test_confidential_client_rejects_unsupported_advertised_methods():
+    with pytest.raises(
+        ValueError,
+        match='does not advertise a supported client-secret',
+    ):
+        select_static_token_endpoint_auth_method(
+            client_secret='client-secret',
+            supported_methods=['private_key_jwt', 'client_secret_jwt'],
+        )

--- a/backend/tests/test_oauth_registration.py
+++ b/backend/tests/test_oauth_registration.py
@@ -1,4 +1,5 @@
 from open_webui.utils.oauth_registration import (
+    overlay_static_oauth_credentials,
     resolve_static_oauth_client_id,
     select_static_token_endpoint_auth_method,
     uses_static_oauth_registration,
@@ -37,6 +38,51 @@ def test_provider_client_id_wins_with_legacy_connection_id_fallback():
         )
         == 'legacy-connection'
     )
+
+
+def test_saved_confidential_credentials_are_preserved_from_encrypted_data():
+    resolved = overlay_static_oauth_credentials(
+        client_data={
+            'client_id': 'provider-client-id',
+            'client_secret': 'encrypted-secret',
+            'token_endpoint_auth_method': 'client_secret_post',
+        },
+        oauth_client_id='provider-client-id',
+        oauth_client_secret=None,
+    )
+
+    assert resolved['client_secret'] == 'encrypted-secret'
+    assert resolved['token_endpoint_auth_method'] == 'client_secret_post'
+
+
+def test_saved_public_credentials_remain_secretless():
+    resolved = overlay_static_oauth_credentials(
+        client_data={
+            'client_id': 'provider-client-id',
+            'client_secret': None,
+            'token_endpoint_auth_method': 'none',
+        },
+        oauth_client_id='provider-client-id',
+        oauth_client_secret=None,
+    )
+
+    assert resolved['client_secret'] is None
+    assert resolved['token_endpoint_auth_method'] == 'none'
+
+
+def test_explicit_static_credentials_override_encrypted_values():
+    resolved = overlay_static_oauth_credentials(
+        client_data={
+            'client_id': 'old-client-id',
+            'client_secret': 'old-secret',
+            'token_endpoint_auth_method': 'client_secret_post',
+        },
+        oauth_client_id='new-client-id',
+        oauth_client_secret='new-secret',
+    )
+
+    assert resolved['client_id'] == 'new-client-id'
+    assert resolved['client_secret'] == 'new-secret'
 
 
 def test_public_client_uses_none_even_when_server_metadata_omits_it():

--- a/backend/tests/test_oauth_registration.py
+++ b/backend/tests/test_oauth_registration.py
@@ -1,0 +1,66 @@
+from open_webui.utils.oauth_registration import (
+    resolve_static_oauth_client_id,
+    select_static_token_endpoint_auth_method,
+    uses_static_oauth_registration,
+)
+
+
+def test_public_client_uses_static_registration_without_secret():
+    assert uses_static_oauth_registration(
+        oauth_client_id='provider-client-id', client_secret=None
+    )
+
+
+def test_legacy_confidential_client_uses_static_registration_from_secret():
+    assert uses_static_oauth_registration(
+        oauth_client_id=None, client_secret='client-secret'
+    )
+
+
+def test_dynamic_registration_is_used_when_no_static_credentials_are_supplied():
+    assert not uses_static_oauth_registration(
+        oauth_client_id=None, client_secret=None
+    )
+    assert not uses_static_oauth_registration(oauth_client_id='', client_secret='')
+
+
+def test_provider_client_id_wins_with_legacy_connection_id_fallback():
+    assert (
+        resolve_static_oauth_client_id(
+            connection_id='bloomberg', oauth_client_id='provider-client-id'
+        )
+        == 'provider-client-id'
+    )
+    assert (
+        resolve_static_oauth_client_id(
+            connection_id='legacy-connection', oauth_client_id=None
+        )
+        == 'legacy-connection'
+    )
+
+
+def test_public_client_uses_none_even_when_server_metadata_omits_it():
+    assert (
+        select_static_token_endpoint_auth_method(
+            client_secret=None,
+            supported_methods=['client_secret_basic', 'client_secret_post'],
+        )
+        == 'none'
+    )
+
+
+def test_confidential_client_prefers_post_and_can_fall_back_to_basic():
+    assert (
+        select_static_token_endpoint_auth_method(
+            client_secret='client-secret',
+            supported_methods=['client_secret_post', 'client_secret_basic'],
+        )
+        == 'client_secret_post'
+    )
+    assert (
+        select_static_token_endpoint_auth_method(
+            client_secret='client-secret',
+            supported_methods=['client_secret_basic'],
+        )
+        == 'client_secret_basic'
+    )

--- a/src/lib/apis/configs/index.ts
+++ b/src/lib/apis/configs/index.ts
@@ -520,6 +520,7 @@ type RegisterOAuthClientForm = {
 	url: string;
 	client_id: string;
 	client_name?: string;
+	oauth_client_id?: string;
 	client_secret?: string;
 	oauth_server_url?: string;
 	oauth_scope?: string;

--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -85,17 +85,17 @@
 			return;
 		}
 
-		if (auth_type === 'oauth_2.1_static' && (!oauthClientId || !oauthClientSecret)) {
-			toast.error($i18n.t('Please enter Client ID and Client Secret'));
+		if (auth_type === 'oauth_2.1_static' && !oauthClientId) {
+			toast.error($i18n.t('Please enter Client ID'));
 			return;
 		}
 
 		// client_id is the tool server ID (used as the internal lookup key for both flows).
-		// For static, client_secret signals the backend to use the static credential path.
-		// The actual OAuth client_id/secret come from the connection info at save time.
+		// oauth_client_id is the provider-issued ID and selects the static credential path.
 		const formData: {
 			url: string;
 			client_id: string;
+			oauth_client_id?: string;
 			client_secret?: string;
 			oauth_server_url?: string;
 			oauth_scope?: string;
@@ -104,7 +104,11 @@
 			client_id: id,
 			...(oauthScope ? { oauth_scope: oauthScope } : {}),
 			...(auth_type === 'oauth_2.1_static'
-				? { client_secret: oauthClientSecret, oauth_server_url: oauthServerUrl }
+				? {
+						oauth_client_id: oauthClientId,
+						...(oauthClientSecret ? { client_secret: oauthClientSecret } : {}),
+						...(oauthServerUrl ? { oauth_server_url: oauthServerUrl } : {})
+					}
 				: {})
 		};
 
@@ -368,8 +372,8 @@
 				...(auth_type === 'oauth_2.1_static'
 					? {
 							oauth_client_id: oauthClientId,
-							oauth_client_secret: oauthClientSecret,
-							oauth_server_url: oauthServerUrl
+							...(oauthClientSecret ? { oauth_client_secret: oauthClientSecret } : {}),
+							...(oauthServerUrl ? { oauth_server_url: oauthServerUrl } : {})
 						}
 					: {})
 			}
@@ -746,7 +750,7 @@
 												/>
 												<SensitiveInput
 													bind:value={oauthClientSecret}
-													placeholder={$i18n.t('Client Secret')}
+													placeholder={$i18n.t('Client Secret (optional)')}
 													required={false}
 												/>
 												<div class="flex flex-1 items-center">


### PR DESCRIPTION
Adds support for pre-registered public OAuth 2.1 MCP clients that use PKCE without a client secret. The UI now sends the provider-issued client ID separately and preserves confidential static and dynamic registration behavior. Tests: six focused pytest cases pass and the changed frontend files pass Prettier. The full svelte-check still reports the repository's existing baseline diagnostics.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update supports pre-registered public OAuth clients and preserves existing confidential static-client credentials. A focused runtime check resolved an encrypted client record with no replacement secret and retained both the secret and `client_secret_post` authentication.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The focused OAuth checks confirmed that encrypted confidential credentials remain intact and that public static registration uses the provider-issued client ID without a client secret.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused OAuth resolution test against resolve\_oauth\_client\_info completed successfully, reporting preserved confidential credentials and the configured authentication method being retained.
- The focused backend registration-route probe for a provider OAuth client ID without a secret exercised the static registration path and returned encrypted information using the provider ID with no secret and no token-endpoint authentication.
- Code-path and runtime behavior were documented, showing that oauth.py decrypts the blob and calls the credential overlay, while the preservation logic in oauth\_registration.py ensures absent credentials do not overwrite existing fields, with the runtime exit code 0.
- The execution capture recorded the exact static-helper arguments and decrypted client-info from a successful static route invocation, and the authored probe source was uploaded alongside the observed output.

<a href="https://app.greptile.com/trex/runs/18513579/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(oauth): reject unsupported client au..."](https://github.com/fposcar/fpwebaiui/commit/5730f588eaa37dcd72b1dadd96634877760e7f3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52602403)</sub>

<!-- /greptile_comment -->