### PR TITLE
Fix model cache recovery after Redis outages

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -237,7 +237,10 @@ from open_webui.utils.middleware import (
     process_chat_payload,
     process_chat_response,
 )
-from open_webui.utils.model_cache import get_model_from_cache_or_refresh
+from open_webui.utils.model_cache import (
+    get_model_from_cache_or_refresh,
+    get_models_from_cache,
+)
 from open_webui.utils.model_ids import strip_provider_model_prefix
 from open_webui.utils.models import (
     check_model_access,
@@ -1057,7 +1060,7 @@ async def chat_completion(
     form_data: dict,
     user=Depends(get_verified_user),
 ):
-    request_models = {}
+    request_models = get_models_from_cache(request)
     models_refreshed = False
 
     async def refresh_models():
@@ -1075,6 +1078,7 @@ async def chat_completion(
         resolved_model, refreshed_models = await get_model_from_cache_or_refresh(
             request,
             model_to_resolve,
+            request_models,
             refresh_models,
         )
         if refreshed_models is not None:
@@ -1575,7 +1579,14 @@ async def chat_completion(
 
     async def process_chat(request, form_data, user, metadata, model, tasks=None):
         try:
-            form_data, metadata, events = await process_chat_payload(request, form_data, user, metadata, model)
+            form_data, metadata, events = await process_chat_payload(
+                request,
+                form_data,
+                user,
+                metadata,
+                model,
+                request_models,
+            )
 
             response = await chat_completion_handler(request, form_data, user)
 
@@ -1594,7 +1605,16 @@ async def chat_completion(
                     detail = f'Provider returned HTTP {response.status_code}'
                 raise Exception(detail)
 
-            ctx = await build_chat_response_context(request, form_data, user, model, metadata, tasks, events)
+            ctx = await build_chat_response_context(
+                request,
+                form_data,
+                user,
+                model,
+                metadata,
+                tasks,
+                events,
+                request_models,
+            )
 
             return await process_chat_response(response, ctx)
         except asyncio.CancelledError:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -237,6 +237,7 @@ from open_webui.utils.middleware import (
     process_chat_payload,
     process_chat_response,
 )
+from open_webui.utils.model_cache import get_model_from_cache_or_refresh
 from open_webui.utils.model_ids import strip_provider_model_prefix
 from open_webui.utils.models import (
     check_model_access,
@@ -1056,8 +1057,31 @@ async def chat_completion(
     form_data: dict,
     user=Depends(get_verified_user),
 ):
-    if not request.app.state.MODELS:
-        await get_all_models(request, user=user)
+    request_models = {}
+    models_refreshed = False
+
+    async def refresh_models():
+        return await get_all_models(request, refresh=True, user=user)
+
+    async def resolve_request_model(model_to_resolve: str):
+        nonlocal request_models, models_refreshed
+
+        if model_to_resolve in request_models:
+            return request_models[model_to_resolve]
+
+        if models_refreshed:
+            return None
+
+        resolved_model, refreshed_models = await get_model_from_cache_or_refresh(
+            request,
+            model_to_resolve,
+            refresh_models,
+        )
+        if refreshed_models is not None:
+            request_models = refreshed_models
+            models_refreshed = True
+
+        return resolved_model
 
     model_id = form_data.get('model', None)
     model_item = form_data.pop('model_item', {})
@@ -1067,10 +1091,10 @@ async def chat_completion(
     try:
         model_info = None
         if not model_item.get('direct', False):
-            if model_id not in request.app.state.MODELS:
+            model = await resolve_request_model(model_id)
+            if model is None:
                 raise Exception('Model not found')
 
-            model = request.app.state.MODELS[model_id]
             model_info = await Models.get_model_by_id(model_id)
 
             # Check if user has access to the model
@@ -1099,15 +1123,20 @@ async def chat_completion(
         # Check base model existence for custom models
         if model_info and model_info.base_model_id:
             base_model_id = model_info.base_model_id
-            if base_model_id not in request.app.state.MODELS:
+            if await resolve_request_model(base_model_id) is None:
                 if ENABLE_CUSTOM_MODEL_FALLBACK:
                     default_models = ((await Config.get('ui.default_models')) or '').split(',')
 
                     fallback_model_id = default_models[0].strip() if default_models[0] else None
 
-                    if fallback_model_id and fallback_model_id in request.app.state.MODELS:
+                    fallback_model = (
+                        await resolve_request_model(fallback_model_id)
+                        if fallback_model_id
+                        else None
+                    )
+                    if fallback_model is not None:
                         # Update model and form_data so routing uses the fallback model's type
-                        model = request.app.state.MODELS[fallback_model_id]
+                        model = fallback_model
                         form_data['model'] = fallback_model_id
                     else:
                         raise Exception('Model not found')
@@ -1727,7 +1756,7 @@ async def chat_completion(
             }
 
             # Resolve the model object for this specific model
-            resolved_model = request.app.state.MODELS.get(target_model_id, model)
+            resolved_model = await resolve_request_model(target_model_id) or model
 
             # Only the first model runs chat-level background tasks;
             # subsequent models only run follow-ups.

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2245,7 +2245,7 @@ async def connect_mcp_server(
     return client, tool_specs
 
 
-async def process_chat_payload(request, form_data, user, metadata, model):
+async def process_chat_payload(request, form_data, user, metadata, model, models):
     # Ensure chat_id is always a string — external API clients may omit it.
     if not isinstance(metadata.get('chat_id'), str):
         metadata['chat_id'] = ''
@@ -2263,7 +2263,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         if arena_model_ids and arena_filter_mode == 'exclude':
             arena_model_ids = [
                 available_model['id']
-                for available_model in request.app.state.MODELS.values()
+                for available_model in models.values()
                 if available_model.get('owned_by') != 'arena' and available_model['id'] not in arena_model_ids
             ]
 
@@ -2272,12 +2272,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         else:
             arena_model_ids = [
                 available_model['id']
-                for available_model in request.app.state.MODELS.values()
+                for available_model in models.values()
                 if available_model.get('owned_by') != 'arena'
             ]
             selected_model_id = random.choice(arena_model_ids)
 
-        selected_model = request.app.state.MODELS.get(selected_model_id)
+        selected_model = models.get(selected_model_id)
         if selected_model:
             model = selected_model
             form_data['model'] = selected_model_id
@@ -2347,11 +2347,11 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     if is_saved_chat_id(chat_id) and user_message_id:
         if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
             compaction_models = {
-                **request.app.state.MODELS,
+                **models,
                 request.state.model['id']: request.state.model,
             }
         else:
-            compaction_models = request.app.state.MODELS
+            compaction_models = models
 
         system_message = get_system_message(form_data.get('messages', []))
         system_prompt = get_content_from_message(system_message) if system_message else ''
@@ -2415,9 +2415,6 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         models = {
             request.state.model['id']: request.state.model,
         }
-    else:
-        models = request.app.state.MODELS
-
     task_model_id = get_task_model_id(
         form_data['model'],
         await Config.get('task.model.default'),
@@ -3005,7 +3002,7 @@ async def get_event_emitter_and_caller(metadata):
     return event_emitter, event_caller
 
 
-async def build_chat_response_context(request, form_data, user, model, metadata, tasks, events):
+async def build_chat_response_context(request, form_data, user, model, metadata, tasks, events, models):
     event_emitter, event_caller = await get_event_emitter_and_caller(metadata)
     return {
         'request': request,
@@ -3015,6 +3012,7 @@ async def build_chat_response_context(request, form_data, user, model, metadata,
         'metadata': metadata,
         'tasks': tasks,
         'events': events,
+        'models': models,
         'event_emitter': event_emitter,
         'event_caller': event_caller,
     }
@@ -3495,7 +3493,7 @@ async def outlet_filter_handler(ctx):
         }
 
         # Pipeline outlet filters
-        models = request.app.state.MODELS
+        models = ctx['models']
         try:
             outlet_data = await process_pipeline_outlet_filter(request, outlet_data, user, models)
         except Exception as e:
@@ -3754,6 +3752,7 @@ async def streaming_chat_response_handler(response, ctx):
 
     user = ctx['user']
     model = ctx['model']
+    models = ctx['models']
 
     metadata = ctx['metadata']
     events = ctx['events']
@@ -5609,7 +5608,7 @@ async def streaming_chat_response_handler(response, ctx):
                     model_id = model.get('id') if isinstance(model, dict) else model
                     has_api_outlet_filters = bool(
                         (isinstance(model, dict) and 'pipeline' in model)
-                        or get_sorted_filters(model_id, request.app.state.MODELS)
+                        or get_sorted_filters(model_id, models)
                     )
                 except Exception:
                     has_api_outlet_filters = True

--- a/backend/open_webui/utils/model_cache.py
+++ b/backend/open_webui/utils/model_cache.py
@@ -15,6 +15,18 @@ def has_model_cache(request: Request) -> bool:
         return bool(fallback)
 
 
+def get_models_from_cache(request: Request) -> dict:
+    """Snapshot the shared cache, falling back locally only when Redis is unavailable."""
+    try:
+        models = request.app.state.MODELS
+        if isinstance(models, dict):
+            return dict(models)
+        return dict(models.items())
+    except Exception as e:
+        log.warning(f'Failed to snapshot Redis model cache, using in-process cache: {e}')
+        return dict(getattr(request.app.state, 'LOCAL_MODELS', {}))
+
+
 def get_model_from_cache(request: Request, model_id: str):
     """Read one model without letting a transient Redis failure break chat routing."""
     try:
@@ -31,6 +43,7 @@ def get_model_from_cache(request: Request, model_id: str):
 async def get_model_from_cache_or_refresh(
     request: Request,
     model_id: str,
+    cached_models: dict,
     refresh_models,
 ):
     """Resolve a model, refreshing once when the shared cache misses it.
@@ -38,9 +51,14 @@ async def get_model_from_cache_or_refresh(
     The refreshed mapping is returned with the selected model so the caller can
     continue using the request-local result even if the Redis write failed.
     """
-    model = get_model_from_cache(request, model_id)
+    model = cached_models.get(model_id)
     if model is not None:
         return model, None
+
+    # Provider discovery is expensive. A populated cache is authoritative for
+    # unknown IDs; refresh only when shared/local state is empty after a restart.
+    if cached_models:
+        return None, None
 
     models = await refresh_models()
     models_dict = {item['id']: item for item in models}

--- a/backend/open_webui/utils/model_cache.py
+++ b/backend/open_webui/utils/model_cache.py
@@ -1,0 +1,62 @@
+import logging
+
+from fastapi import Request
+
+log = logging.getLogger(__name__)
+
+
+def has_model_cache(request: Request) -> bool:
+    """Return whether a shared model cache is available, with a local outage fallback."""
+    try:
+        return bool(request.app.state.MODELS)
+    except Exception as e:
+        fallback = getattr(request.app.state, 'LOCAL_MODELS', {})
+        log.warning(f'Failed to read Redis model cache, using in-process cache: {e}')
+        return bool(fallback)
+
+
+def get_model_from_cache(request: Request, model_id: str):
+    """Read one model without letting a transient Redis failure break chat routing."""
+    try:
+        return request.app.state.MODELS[model_id]
+    except KeyError:
+        # A healthy shared cache is authoritative. Do not resurrect a model that
+        # was deliberately removed but still exists in this process's fallback.
+        return None
+    except Exception as e:
+        log.warning(f'Failed to read model {model_id!r} from Redis, using in-process cache: {e}')
+        return getattr(request.app.state, 'LOCAL_MODELS', {}).get(model_id)
+
+
+async def get_model_from_cache_or_refresh(
+    request: Request,
+    model_id: str,
+    refresh_models,
+):
+    """Resolve a model, refreshing once when the shared cache misses it.
+
+    The refreshed mapping is returned with the selected model so the caller can
+    continue using the request-local result even if the Redis write failed.
+    """
+    model = get_model_from_cache(request, model_id)
+    if model is not None:
+        return model, None
+
+    models = await refresh_models()
+    models_dict = {item['id']: item for item in models}
+    return models_dict.get(model_id), models_dict
+
+
+def update_model_cache(request: Request, models_dict: dict) -> None:
+    # Keep a per-process copy so requests can continue during a Redis outage.
+    # Crucially, retain the RedisDict itself so the process reconnects to shared
+    # state once Redis recovers instead of diverging permanently.
+    request.app.state.LOCAL_MODELS = models_dict
+
+    if hasattr(request.app.state.MODELS, 'set'):
+        try:
+            request.app.state.MODELS.set(models_dict)
+        except Exception as e:
+            log.warning(f'Failed to update Redis model cache, using in-process cache: {e}')
+    else:
+        request.app.state.MODELS = models_dict

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -19,8 +19,8 @@ from open_webui.models.models import Models
 from open_webui.utils.chat_variables import get_chat_variables_schema
 from open_webui.models.users import UserModel
 from open_webui.routers import ollama, openai
-from open_webui.socket.utils import RedisDict
 from open_webui.utils.access_control import has_access, has_base_model_access
+from open_webui.utils.model_cache import has_model_cache, update_model_cache
 from open_webui.utils.plugin import (
     get_functions_cache,
     get_function_module_from_cache,
@@ -72,7 +72,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
         'models.default_metadata',
     )
     if (
-        request.app.state.MODELS
+        has_model_cache(request)
         and request.app.state.BASE_MODELS
         and (config.get('models.base_models_cache') and not refresh)
     ):
@@ -416,14 +416,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
     log.debug(f'get_all_models() returned {len(models)} models')
 
     models_dict = {model['id']: model for model in models}
-    if isinstance(request.app.state.MODELS, RedisDict):
-        try:
-            request.app.state.MODELS.set(models_dict)
-        except Exception as e:
-            log.warning(f'Failed to update Redis model cache, using in-process cache: {e}')
-            request.app.state.MODELS = models_dict
-    else:
-        request.app.state.MODELS = models_dict
+    update_model_cache(request, models_dict)
 
     return models
 

--- a/backend/tests/test_model_cache_resilience.py
+++ b/backend/tests/test_model_cache_resilience.py
@@ -23,6 +23,10 @@ class FakeModelCache:
         self._raise_if_unavailable()
         return len(self.values)
 
+    def items(self):
+        self._raise_if_unavailable()
+        return self.values.items()
+
     def set(self, mapping):
         self._raise_if_unavailable()
         self.values = mapping
@@ -42,6 +46,7 @@ def test_redis_read_failure_uses_last_in_process_model_cache():
     request = make_request(cache, {'gpt-test': expected})
 
     assert model_cache.has_model_cache(request)
+    assert model_cache.get_models_from_cache(request) == {'gpt-test': expected}
     assert model_cache.get_model_from_cache(request, 'gpt-test') is expected
 
 
@@ -77,6 +82,7 @@ def test_model_cache_miss_refreshes_and_returns_request_local_mapping():
         model_cache.get_model_from_cache_or_refresh(
             request,
             'gpt-test',
+            {},
             refresh_models,
         )
     )
@@ -84,3 +90,25 @@ def test_model_cache_miss_refreshes_and_returns_request_local_mapping():
     assert model is expected
     assert refreshed_models == {'gpt-test': expected}
     assert calls == ['refresh']
+
+
+def test_unknown_model_in_populated_cache_does_not_refresh_providers():
+    request = make_request(FakeModelCache(values={'known-model': {'id': 'known-model'}}))
+    calls = []
+
+    async def refresh_models():
+        calls.append('refresh')
+        return []
+
+    model, refreshed_models = asyncio.run(
+        model_cache.get_model_from_cache_or_refresh(
+            request,
+            'unknown-model',
+            model_cache.get_models_from_cache(request),
+            refresh_models,
+        )
+    )
+
+    assert model is None
+    assert refreshed_models is None
+    assert calls == []

--- a/backend/tests/test_model_cache_resilience.py
+++ b/backend/tests/test_model_cache_resilience.py
@@ -1,0 +1,86 @@
+import asyncio
+from types import SimpleNamespace
+
+from open_webui.utils import model_cache
+
+
+class FakeModelCache:
+    def __init__(self, *, values=None, error=None):
+        self.values = values or {}
+        self.error = error
+
+    def _raise_if_unavailable(self):
+        if self.error:
+            raise self.error
+
+    def __getitem__(self, key):
+        self._raise_if_unavailable()
+        if key not in self.values:
+            raise KeyError(key)
+        return self.values[key]
+
+    def __len__(self):
+        self._raise_if_unavailable()
+        return len(self.values)
+
+    def set(self, mapping):
+        self._raise_if_unavailable()
+        self.values = mapping
+
+
+def make_request(cache, local_models=None):
+    state = SimpleNamespace(
+        MODELS=cache,
+        LOCAL_MODELS=local_models or {},
+    )
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+def test_redis_read_failure_uses_last_in_process_model_cache():
+    expected = {'id': 'gpt-test'}
+    cache = FakeModelCache(error=ConnectionError('redis unavailable'))
+    request = make_request(cache, {'gpt-test': expected})
+
+    assert model_cache.has_model_cache(request)
+    assert model_cache.get_model_from_cache(request, 'gpt-test') is expected
+
+
+def test_healthy_redis_miss_does_not_resurrect_stale_local_model():
+    cache = FakeModelCache()
+    request = make_request(cache, {'removed-model': {'id': 'removed-model'}})
+
+    assert model_cache.get_model_from_cache(request, 'removed-model') is None
+
+
+def test_failed_redis_write_retains_shared_cache_object_and_updates_fallback():
+    cache = FakeModelCache(error=ConnectionError('redis unavailable'))
+    request = make_request(cache)
+    expected = {'gpt-test': {'id': 'gpt-test'}}
+
+    model_cache.update_model_cache(request, expected)
+
+    assert request.app.state.MODELS is cache
+    assert request.app.state.LOCAL_MODELS is expected
+
+
+def test_model_cache_miss_refreshes_and_returns_request_local_mapping():
+    cache = FakeModelCache()
+    request = make_request(cache)
+    expected = {'id': 'gpt-test', 'name': 'Test model'}
+    calls = []
+
+    async def refresh_models():
+        calls.append('refresh')
+        return [expected]
+
+    model, refreshed_models = asyncio.run(
+        model_cache.get_model_from_cache_or_refresh(
+            request,
+            'gpt-test',
+            refresh_models,
+        )
+    )
+
+    assert model is expected
+    assert refreshed_models == {'gpt-test': expected}
+    assert calls == ['refresh']


### PR DESCRIPTION
## Summary
- retain the Redis-backed model cache after transient write failures and use a process-local fallback during outages
- refresh model metadata once on cache misses and resolve the current request from the returned mapping
- add regression coverage for Redis read/write failures, stale local entries, and refresh-on-miss behavior

## Verification
- 4 focused model-cache regression tests passed
- Python AST parsing passed for all changed files
- git diff --check passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a process-local fallback for model-cache failures and refreshes model metadata when a requested model is absent. Repeated requests for the same unknown model were verified to force a full model refresh each time even when the cache is healthy and populated, causing avoidable provider-discovery and database work. This should be addressed before merge.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is because repeated invalid model requests can repeatedly invoke full model discovery work.

The affected cache-miss path was executed with a populated cache and an instrumented refresh callback. Two identical unknown-model requests produced two refreshes, and the route wiring confirms that each refresh calls the full refreshed model lookup.

**Files Needing Attention:** backend/open_webui/utils/model_cache.py needs miss handling that avoids repeated refreshes; backend/open_webui/main.py contains the callback that turns each refresh into model and provider discovery.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced finding-comment-proof for a posted P2 finding and linked it to harness evidence and resilience test output.
- T-Rex validated contract behavior by showing that two invalid requests now trigger two refresh calls while the shared cache remains populated, and explained how main.py wires refresh to get\_all\_models(request, refresh=True, user=user).

<a href="https://app.greptile.com/trex/runs/20772002/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Invalid chat model IDs force a full model refresh on every request**

   - **Bug**
     - For a populated healthy model cache, each separate authenticated chat request for a nonexistent model reaches the cache-miss branch and invokes `get_all_models(request, refresh=True, user=user)`. The focused two-request execution observed two refresh invocations for the same invalid ID, whereas the parent behavior made none with a populated cache.
   - **Cause**
     - `get_model_from_cache_or_refresh` refreshes unconditionally after a cache miss and does not cache negative results. The chat endpoint's `models_refreshed` guard is request-local, so it cannot suppress refreshes across invalid requests.
   - **Fix**
     - Avoid forced discovery for misses in an already-populated healthy cache, or add a bounded negative cache/single-flight refresh mechanism so repeated unknown IDs do not repeatedly trigger provider and database discovery.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Fix model cache recovery after Redis out..."](https://github.com/fposcar/fpwebaiui/commit/32a046105c155c8fe139fb46c977fb885f65581d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57007646)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->